### PR TITLE
Updates to core module

### DIFF
--- a/Src/Public/New-AsBuiltConfig.ps1
+++ b/Src/Public/New-AsBuiltConfig.ps1
@@ -162,7 +162,7 @@ function New-AsBuiltConfig {
         #If the folder is not empty, do a foreach loop through each currently installed report module and check if the
         #report json specific to that module exists. If it does, prompt the user to see if they want to overwrite the
         #JSON. If it doesn't exist, generate the JSON
-        $AsBuiltReportModules = Get-Module -Name "AsBuiltReport.*"
+        $AsBuiltReportModules = Get-Module -Name "AsBuiltReport.*" -ListAvailable | Where-Object { $_.name -ne 'AsBuiltReport.Core' }
         if (!(Get-ChildItem -Path $ReportConfigFolder -Force)) {
             Foreach ($AsBuiltReportModule in $AsBuiltReportModules) {
                 $AsBuiltReportName = $AsBuiltReportModule.Name.Replace("AsBuiltReport.", "")
@@ -183,22 +183,10 @@ function New-AsBuiltConfig {
                         $OverwriteReportJSON = Read-Host -Prompt "A report JSON already exists in the specified folder for $($AsBuiltReportModule.Name). Would you like to overwrite it? (y/n)"
                         while ("y", "n" -notcontains $OverwriteReportJSON) {
                             $OverwriteReportJSON = Read-Host -Prompt "A report JSON already exists in the specified folder for $($AsBuiltReportModule.Name). Would you like to overwrite it? (y/n)"
-                            while ("y", "n" -notcontains $OverwriteReportJSON) {
-                                $OverwriteReportJSON = Read-Host -Prompt "A report JSON already exists in the specified folder for $($AsBuiltReportModule.Name). Would you like to overwrite it? (y/n)"
-                            }
-                            if ($OverwriteReportJSON -eq 'y') {
-                                Try {
-                                    New-AsBuiltReportConfig -Report $AsBuiltReportName -Path $ReportConfigFolder
-                                }
-                                Catch {
-                                    Write-Error $_
-                                    Break
-                                }
-                            }
                         }
-                        else {
+                        if ($OverwriteReportJSON -eq 'y') {
                             Try {
-                                New-AsBuiltReportConfig -Report $AsBuiltReportName -Path $ReportConfigFolder
+                                New-AsBuiltReportConfig -Report $AsBuiltReportName -Path $ReportConfigFolder -Overwrite
                             }
                             Catch {
                                 Write-Error $_

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -92,7 +92,7 @@ function New-AsBuiltReport {
             HelpMessage = 'Please specify which report type you wish to run.'
         )]
         [ValidateScript( {
-                $InstalledReportModules = Get-Module -Name "AsBuiltReport.*" -ListAvailable
+                $InstalledReportModules = Get-Module -Name "AsBuiltReport.*" -ListAvailable | Where-Object { $_.name -ne 'AsBuiltReport.Core' }
                 $ValidReports = foreach ($InstalledReportModule in $InstalledReportModules) {
                     $NameArray = $InstalledReportModule.Name.Split('.')
                     "$($NameArray[-2]).$($NameArray[-1])"
@@ -339,14 +339,14 @@ function New-AsBuiltReport {
         #endregion Send-Email
 
         #region Globals cleanup
-        Clear-Variable -Name AsBuiltConfig -Scope Global
-        Clear-Variable -Name ReportConfig -Scope Global
-        Clear-Variable -Name Orientation -Scope Global
+        Remove-Variable -Name AsBuiltConfig -Scope Global
+        Remove-Variable -Name ReportConfig -Scope Global
+        Remove-Variable -Name Orientation -Scope Global
         if ($ReportConfigPath) {
-            Clear-Variable -Name ReportConfigPath
+            Remove-Variable -Name ReportConfigPath
         }
         if ($Healthcheck) {
-            Clear-Variable -Name Healthcheck -Scope Global
+            Remove-Variable -Name Healthcheck -Scope Global
         }
         #endregion Globals cleanup
 
@@ -365,7 +365,7 @@ Register-ArgumentCompleter -CommandName 'New-AsBuiltReport' -ParameterName 'Repo
         $fakeBoundParameter
     )
 
-    $InstalledReportModules = Get-Module -Name "AsBuiltReport.*" -ListAvailable
+    $InstalledReportModules = Get-Module -Name "AsBuiltReport.*" -ListAvailable | Where-Object { $_.name -ne 'AsBuiltReport.Core' }
     $ValidReports = foreach ($InstalledReportModule in $InstalledReportModules) {
         $NameArray = $InstalledReportModule.Name.Split('.')
         "$($NameArray[-2]).$($NameArray[-1])"


### PR DESCRIPTION
- Add where-object to filter "AsBuiltReport.Core" from Get-Module cmdlets
- Tidied up section in New-AsBuiltConfig where is prompts the user if they want to overwrite report JSON files in the destination
- Add -overwrite parameter to New-AsBuiltReportConfig to allow New-AsBuiltConfig to call New-AsBuiltReportConfig after asking the user if they want to overwrite the report JSON
- Change "clear-variable" to "remove-variable" in New-AsbuiltReport to resolve an issue where variables being defined caused issues with New-AsBuiltConfig