### PR TITLE
Issue Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AsBuiltReport.Core Changelog
 
+## Unreleased
+### Added
+- DefaultParameterSetName to New-AsBuiltReport so a user can run the cmdlet without any parameters
+- Check if OutputPath for New-AsBuiltReport exists before running the report script and error if it doesn't exist
+- Add default action to credential parameter on New-AsBuiltReport
+
 ## [1.0.0] - 2019-03-26
 ### Added
 - `AsBuiltReport.Core` module created to provide core as built report functionality

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -83,7 +83,8 @@ function New-AsBuiltReport {
 
     #region Script Parameters
     [CmdletBinding(
-        PositionalBinding = $false
+        PositionalBinding = $false,
+        DefaultParameterSetName = 'Credential'
     )]
     param (
         [Parameter(
@@ -121,7 +122,7 @@ function New-AsBuiltReport {
             ParameterSetName = 'Credential'
         )]
         [ValidateNotNullOrEmpty()]
-        [PSCredential] $Credential,
+        [PSCredential] $Credential = (Get-Credential),
 
         [Parameter(
             Position = 2,
@@ -211,6 +212,11 @@ function New-AsBuiltReport {
         if (($Username -and $Password)) {
             $SecurePassword = ConvertTo-SecureString $Password -AsPlainText -Force
             $Credential = New-Object System.Management.Automation.PSCredential ($Username, $SecurePassword)
+        }
+
+        if (!(Test-Path $OutputPath)) {
+            Write-Error "OutputPath $OutputPath is not a valid directory path"
+            break
         }
 
         #region Variable config


### PR DESCRIPTION
- Implement DefaultParameterSetName on New-AsbuiltReport. Resolves Issue #13 (https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/13)
- Check if OutputPath for New-AsBuiltReport exists before running the report script and error if it doesn't exist. Fixes Issue #14 (https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/14)
