### PR TITLE
Adding support for -Verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # AsBuiltReport.Core Changelog
 
-## {Unreleased]
+## [Unreleased]
 ### Added
 - Added support for using the -Verbose switch with New-AsBuiltReport as per [Issue 28](https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # AsBuiltReport.Core Changelog
 
+## {Unreleased]
+### Added
+- Added support for using the -Verbose switch with New-AsBuiltReport as per [Issue 28](https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/28)
+
 ## [1.0.3] - 2020-02-27
 ### Changed
 - Updated RequiredModules to use PScribo 0.7.26
 
 ### Fixed
 - Fixed truncated tables when using text output (Fix #26)
-
-### Added
-- Added support for using the -Verbose switch with New-AsBuiltReport as per [Issue 28](https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/28)
 
 ## [1.0.2] - 2019-06-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 - Fixed truncated tables when using text output (Fix #26)
 
+### Added
+- Added support for using the -Verbose switch with New-AsBuiltReport as per [Issue 28](https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/28)
+
 ## [1.0.2] - 2019-06-21
 ### Changed
 - Updated module manifest icon and release notes URI

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Here are some examples to get you going.
 # The document will highlight particular issues which exist within the environment by including the Healthchecks switch.
 PS C:\>New-AsBuiltReport -Report VMware.vSphere -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -EnableHealthCheck -OutputPath 'H:\Documents\'
 
+# The following creates a VMware vSphere As Built report in HTML & Word formats, while displaying Verbose messages to the console
+PS C:\>New-AsBuiltReport -Report VMware.vSphere -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -OutputPath 'H:\Documents\' -Verbose
+
 # The following creates a Pure Storage FlashArray As Built report in Text format and appends a timestamp to the filename. It also uses stored credentials to connect to the system.
 PS C:\>$Creds = Get-Credential
 PS C:\>New-AsBuiltReport -Report PureStorage.FlashArray -Target 192.168.1.100 -Credential $Creds -Format Text -Timestamp -OutputPath 'H:\Documents\'

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -296,13 +296,26 @@ function New-AsBuiltReport {
         #endregion Email Server Authentication
 
         #region Generate PScribo document
-        $AsBuiltReport = Document $FileName -Verbose {
-            # Set Document Style
-            if ($StylePath) {
-                .$StylePath
+        # if Verbose has been passed
+        if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) {
+            $AsBuiltReport = Document $FileName -Verbose {
+                # Set Document Style
+                if ($StylePath) {
+                    .$StylePath
+                }
+    
+                & "Invoke-$($ReportModule)" -Target $Target -Credential $Credential -StylePath $StylePath -Verbose
             }
-
-            & "Invoke-$($ReportModule)" -Target $Target -Credential $Credential -StylePath $StylePath
+        }
+        else {
+            $AsBuiltReport = Document $FileName {
+                # Set Document Style
+                if ($StylePath) {
+                    .$StylePath
+                }
+    
+                & "Invoke-$($ReportModule)" -Target $Target -Credential $Credential -StylePath $StylePath
+            }
         }
         Try {
             $Document = $AsBuiltReport | Export-Document -Path $OutputPath -Format $Format -Options @{ TextWidth = 240 } -PassThru


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding support for using the -Verbose switch when creating new reports with the New-AsBuiltReport cmdlet

## Description
Added a simple if statement to check the presense of the -Verbose switch.  If utilized, the PScribo cmdlets and Report related cmdlets are called with -Verbose, otherwise, they aren't.

## Related Issue
Resolves [Issue 28](https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/28)

## Motivation and Context
This allows end users to specify whether or not they wish to see verbose logging messages on the console.
This also allows developers of new reports to utilize the Write-Verbose cmdlet to better troubleshoot errors.

## How Has This Been Tested?

Tested by running various reports specify verbose and not.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
