### PR TITLE
v1.1.0 release

### DIFF
--- a/AsBuiltReport.Core.psd1
+++ b/AsBuiltReport.Core.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion = '1.0.5'
+    ModuleVersion = '1.1.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = 'Desktop'
@@ -55,7 +55,7 @@
     RequiredModules = @(
         @{
             ModuleName = 'PScribo'; 
-            ModuleVersion = '0.9.0'
+            ModuleVersion = '0.9.1'
         }
     )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # :arrows_counterclockwise: AsBuiltReport.Core Changelog
 
+## [1.1.0] - 2020-08-16
+### Changed 
+- Updated `New-AsBuiltReport` parameter names to provide clarity of input requirements. Aliases used to prevent breaking changes.
+    - `OutputPath` now an alias for `OutputFolderPath`
+    - `StylePath` now an alias for `StyleFilePath`
+    - `ReportConfigPath` now an alias for `ReportConfigFilePath`
+    - `AsBuiltConfigPath` now an alias for `AsBuiltConfigFilePath`
+- Updated `New-AsBuiltReportConfig` parameter names to provide clarity of input requirements. Aliases used to prevent breaking changes.
+    - `Path` now an alias for `FolderPath`
+    - `Name` now an alias for `Filename`
+    - `Overwrite` now an alias for `Force`
+- Updated `RequiredModules` for PScribo 0.9.1
+- Custom style scripts are now executed from `New-AsBuiltReport` to allow use of new PScribo features
+
+### Added
+- Added `Filename` parameter to `New-AsBuiltReport`
+- Added error check for incorrect `AsBuiltConfigFilePath`
+- Improvements to verbose logging
+
 ## [1.0.5] - 2020-07-16
 ### Changed
 - Updated `RequiredModules` for PScribo 0.9.0

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ This report is compatible with the following PowerShell versions;
 |:----------------------:|:------------------:|:------------------:|
 |   :white_check_mark:   | :white_check_mark: | :white_check_mark: |
 
-## :wrench: Pre-requisites
+## :wrench: System Requirements
 
 The following module will be automatically installed by following the [module installation](https://github.com/AsBuiltReport/AsBuiltReport.Core#package-module-installation) procedure.
 
-This module may also be installed individually.
+This module may also be manually installed.
 
 | Module Name        | Minimum Required Version |                          PS Gallery                           |                                   GitHub                                    |
 |--------------------|:------------------------:|:---------------------------------------------------------------------:|:---------------------------------------------------------------------------:|
-| PScribo            |          0.9.0           |      [Link](https://www.powershellgallery.com/packages/PScribo)       |         [Link](https://github.com/iainbrighton/PScribo/tree/master)
+| PScribo            |          0.9.1           |      [Link](https://www.powershellgallery.com/packages/PScribo)       |         [Link](https://github.com/iainbrighton/PScribo/tree/master)
 
 To find a list of available report modules, run the following PowerShell command;
 
@@ -66,7 +66,7 @@ install-module AsBuiltReport.Core
 ```
 
 ### **GitHub**
-If you are unable to use the PowerShell Gallery, you can still install the module manually. Ensure you repeat the following steps for the [pre-requistes](https://github.com/AsBuiltReport/AsBuiltReport.Core#wrench-pre-requisites) also.
+If you are unable to use the PowerShell Gallery, you can still install the module manually. Ensure you repeat the following steps for the [system requirements](https://github.com/AsBuiltReport/AsBuiltReport.Core#wrench-system-requirements) also.
 
 1. Download the [latest release](https://github.com/AsBuiltReport/AsBuiltReport.Core/releases/latest) zip from GitHub
 2. Extract the zip file
@@ -99,15 +99,17 @@ The `New-AsBuiltReport` cmdlet is used to generate as built reports. The type of
     Specifies the password for the target system.
 .PARAMETER Format
     Specifies the output format of the report.
-    The supported output formats are WORD, HTML, XML & TEXT.
+    The supported output formats are WORD, HTML & TEXT.
     Multiple output formats may be specified, separated by a comma.
 .PARAMETER Orientation
     Sets the page orientation of the report to Portrait or Landscape.
     By default, page orientation will be set to Portrait.
-.PARAMETER StylePath
-    Specifies the path to a custom style .ps1 script for the report to use.
-.PARAMETER OutputPath
-    Specifies the path to save the report.
+.PARAMETER StyleFilePath
+    Specifies the file path to a custom style .ps1 script for the report to use.
+.PARAMETER OutputFolderPath
+    Specifies the folder path to save the report.
+.PARAMETER Filename
+    Specifies a filename for the report.
 .PARAMETER Timestamp
     Specifies whether to append a timestamp string to the report filename.
     By default, the timestamp string is not added to the report filename.
@@ -116,12 +118,12 @@ The `New-AsBuiltReport` cmdlet is used to generate as built reports. The type of
     Not all reports may provide this functionality.
 .PARAMETER SendEmail
     Sends report to specified recipients as email attachments.
-.PARAMETER AsBuiltConfigPath
+.PARAMETER AsBuiltConfigFilePath
     Enter the full path to the As Built Report configuration JSON file.
     If this parameter is not specified, the user will be prompted for this configuration information on first 
     run, with the option to save the configuration to a file.
-.PARAMETER ReportConfigPath
-    Enter the full path to a report JSON configuration file
+.PARAMETER ReportConfigFilePath
+    Enter the full path to a report JSON configuration file.
     If this parameter is not specified, a default report configuration JSON is copied to the specifed user folder.
     If this paramter is specified and the path to a JSON file is invalid, the script will terminate
 ```
@@ -133,9 +135,9 @@ Get-Help New-AsBuiltReport -Full
 ```
 
 ### **New-AsBuiltConfig**
-`New-AsBuiltConfig` starts a menu-driven procedure in the powershell console and asks the user a series of questions. Answers to these questions are optionally saved in a JSON configuration file which can then be referenced using the `-AsBuiltConfigPath` parameter using `New-AsBuiltReport`, to save having to answer these questions again and also to allow the automation of `New-AsBuiltReport`.
+`New-AsBuiltConfig` starts a menu-driven procedure in the powershell console and asks the user a series of questions. Answers to these questions are optionally saved in a JSON configuration file which can then be referenced using the `-AsBuiltConfigFilePath` parameter using `New-AsBuiltReport`, to save having to answer these questions again and also to allow the automation of `New-AsBuiltReport`.
         
-`New-AsBuiltConfig` will automatically be called by `New-AsBuiltReport` if the `-AsBuiltConfigPath` parameter is not specified. If a user wants to generate a new As Built JSON configuration without running a new report, this cmdlet can be called as a standalone cmdlet.
+`New-AsBuiltConfig` will automatically be called by `New-AsBuiltReport` if the `-AsBuiltConfigFilePath` parameter is not specified. If a user wants to generate a new As Built JSON configuration without running a new report, this cmdlet can be called as a standalone cmdlet.
 
 ### **New-AsBuiltReportConfig**
 
@@ -144,19 +146,19 @@ The `New-AsBuiltReportConfig` cmdlet is used to create JSON configuration files 
 ```powershell
 .PARAMETER Report
     Specifies the type of report configuration to create.
-.PARAMETER Path
-    Specifies the path to create the report JSON configuration file.
-.PARAMETER Name
-    Specifies the name of the report JSON configuration file.
+.PARAMETER FolderPath
+    Specifies the folder path to create the report JSON configuration file.
+.PARAMETER Filename
+    Specifies the filename of the report JSON configuration file.
     If Name is not specified, a JSON configuration file will be created with a default name AsBuiltReport.<Vendor>.<Product>.json
-.PARAMETER Overwrite
-        Specifies to overwrite any existing report JSON configuration file
+.PARAMETER Force
+    Specifies to overwrite any existing report JSON configuration file
 .EXAMPLE
     Creates a report JSON configuration file for VMware vSphere, named 'vSphere_Report_Config' in 'C:\Reports' folder. 
-    New-AsBuiltReportConfig -Report VMware.vSphere -Path 'C:\Reports' -Name 'vSphere_Report_Config'
+    New-AsBuiltReportConfig -Report VMware.vSphere -FolderPath 'C:\Reports' -Filename 'vSphere_Report_Config'
 .EXAMPLE
     Creates a report JSON configuration file for Nutanix Prism Central, named 'AsBuiltReport.Nutanix.PrismCentral' in 'C:\Reports' folder, overwriting any existing file. 
-    New-AsBuiltReportConfig -Report Nutanix.PrismCentral -Path 'C:\Reports' -Overwrite
+    New-AsBuiltReportConfig -Report Nutanix.PrismCentral -FolderPath 'C:\Reports' -Force
 ```
 
 ```powershell
@@ -169,20 +171,23 @@ Here are some examples to get you going.
 ```powershell
 # The following creates a VMware vSphere As Built report in HTML & Word formats.
 # The document will highlight particular issues which exist within the environment by including the Healthchecks switch.
-PS C:\>New-AsBuiltReport -Report VMware.vSphere -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -EnableHealthCheck -OutputPath 'H:\Documents\'
+PS C:\>New-AsBuiltReport -Report VMware.vSphere -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -EnableHealthCheck -OutputFolderPath 'H:\Documents\'
 
 # The following creates a VMware vSphere As Built report in HTML & Word formats, while displaying Verbose messages to the console
-PS C:\>New-AsBuiltReport -Report VMware.vSphere -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -OutputPath 'H:\Documents\' -Verbose
+PS C:\>New-AsBuiltReport -Report VMware.vSphere -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -OutputFolderPath 'H:\Documents\' -Verbose
 
 # The following creates a Pure Storage FlashArray As Built report in Text format and appends a timestamp to the filename. It also uses stored credentials to connect to the system.
 PS C:\>$Creds = Get-Credential
-PS C:\>New-AsBuiltReport -Report PureStorage.FlashArray -Target 192.168.1.100 -Credential $Creds -Format Text -Timestamp -OutputPath 'H:\Documents\'
+PS C:\>New-AsBuiltReport -Report PureStorage.FlashArray -Target 192.168.1.100 -Credential $Creds -Format Text -Timestamp -OutputFolderPath 'H:\Documents\'
 
-# The following creates a Cisco UCS As Built report in default format (Word) with a customised style.
-PS C:\>New-AsBuiltReport -Report Cisco.UCSManager -Target 192.168.1.100 -Username admin -Password admin -StylePath 'C:\scripts\ACME.ps1' -OutputPath 'H:\Documents\'
+# The following creates a Cisco UCS Manager As Built report in default format (Word) with a customised style.
+PS C:\>New-AsBuiltReport -Report Cisco.UCSManager -Target 192.168.1.100 -Username admin -Password admin -StyleFilePath 'C:\scripts\ACME.ps1' -OutputFolderPath 'H:\Documents\'
 
 # The following creates a VMware NSX-V As Built report in HTML format, using the configuration in the asbuilt.json file located in the C:\scripts\ folder.
-PS C:\>New-AsBuiltReport -Report VMware.NSXv -Target 192.168.1.100 -Username admin -Password admin -Format HTML -AsBuiltConfigPath 'C:\scripts\asbuilt.json' -OutputPath 'H:\Documents\'
+PS C:\>New-AsBuiltReport -Report VMware.NSXv -Target 192.168.1.100 -Username admin -Password admin -Format HTML -AsBuiltConfigFilePath 'C:\scripts\asbuilt.json' -OutputFolderPath 'H:\Documents\'
+
+# The following creates a Nutanix Prism Element As Built report in HTML format, with a custom filename.
+PS C:\>New-AsBuiltReport -Report VMware.NSXv -Target 192.168.1.100 -Username admin -Password admin -Format HTML -AsBuiltConfigFilePath 'C:\scripts\asbuilt.json' -OutputFolderPath 'H:\Documents\' -Filename 'My Nutanix Configuration'
 ```
 
 ## :pencil: Notes

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
             <img src="https://img.shields.io/twitter/follow/AsBuiltReport.svg?style=social"/></a>
 </p>
 
-# AsBuiltReport
+# AsBuiltReport.Core
 
 AsBuiltReport.Core is a PowerShell module which provides the core framework for generating as built documentation for many common datacentre systems. The AsBuiltReport.Core module is required by each individual report module used to generate as built documentation for a specific product and/or technology.
 

--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -1,9 +1,9 @@
 function New-AsBuiltReport {
     <#
     .SYNOPSIS  
-        Documents the configuration of IT infrastructure in Word/HTML/XML/Text formats using PScribo.
+        Documents the configuration of IT infrastructure in Word/HTML/Text formats using PScribo.
     .DESCRIPTION
-        Documents the configuration of IT infrastructure in Word/HTML/XML/Text formats using PScribo.
+        Documents the configuration of IT infrastructure in Word/HTML/Text formats using PScribo.
     .PARAMETER Report
         Specifies the type of report that will be generated.
     .PARAMETER Target
@@ -17,15 +17,17 @@ function New-AsBuiltReport {
         Specifies the password for the target system.
     .PARAMETER Format
         Specifies the output format of the report.
-        The supported output formats are WORD, HTML, XML & TEXT.
+        The supported output formats are WORD, HTML & TEXT.
         Multiple output formats may be specified, separated by a comma.
     .PARAMETER Orientation
         Sets the page orientation of the report to Portrait or Landscape.
         By default, page orientation will be set to Portrait.
-    .PARAMETER StylePath
-        Specifies the path to a custom style .ps1 script for the report to use.
-    .PARAMETER OutputPath
-        Specifies the path to save the report.
+    .PARAMETER StyleFilePath
+        Specifies the file path to a custom style .ps1 script for the report to use.
+    .PARAMETER OutputFolderPath
+        Specifies the folder path to save the report.
+    .PARAMETER Filename
+        Specifies a filename for the report.
     .PARAMETER Timestamp
         Specifies whether to append a timestamp string to the report filename.
         By default, the timestamp string is not added to the report filename.
@@ -34,43 +36,39 @@ function New-AsBuiltReport {
         Not all reports may provide this functionality.
     .PARAMETER SendEmail
         Sends report to specified recipients as email attachments.
-    .PARAMETER AsBuiltConfigPath
-        Enter the full path to the As Built Report configuration JSON file.
+    .PARAMETER AsBuiltConfigFilePath
+        Enter the full file path to the As Built Report configuration JSON file.
         If this parameter is not specified, the user will be prompted for this configuration information on first 
         run, with the option to save the configuration to a file.
-    .PARAMETER ReportConfigPath
-        Enter the full path to a report JSON configuration file
+    .PARAMETER ReportConfigFilePath
+        Enter the full file path to a report JSON configuration file
         If this parameter is not specified, a default report configuration JSON is copied to the specifed user folder.
-        If this paramter is specified and the path to a JSON file is invalid, the script will terminate
+        If this paramter is specified and the path to a JSON file is invalid, the script will terminate.
     .EXAMPLE
-        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -Report VMware.vSphere -EnableHealthCheck -OutputPath c:\scripts\
-
+        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Format HTML,Word -Report VMware.vSphere -EnableHealthCheck -OutputFolderPath c:\scripts\
         Creates a VMware vSphere As Built Report in HTML & Word formats. The document will highlight particular issues which exist within the environment.
         The report will be saved to c:\scripts.
     .EXAMPLE
         PS C:\>$Creds = Get-Credential
-        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Credential $Creds -Format Text -Report PureStorage.FlashArray -Timestamp -OutputPath c:\scripts\
-
+        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Credential $Creds -Format Text -Report PureStorage.FlashArray -Timestamp -OutputFolderPath c:\scripts\
         Creates a Pure Storage FlashArray As Built Report in Text format and appends a timestamp to the filename. 
         Stored credentials are used to connect to the system.
         The report will be saved to c:\scripts.
     .EXAMPLE
-        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Report Cisco.UCSManager -StylePath c:\scripts\AsBuiltReport\Styles\ACME.ps1 -OutputPath c:\scripts\
-
+        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Report Cisco.UCSManager -StyleFilePath c:\scripts\AsBuiltReport\Styles\ACME.ps1 -OutputFolderPath c:\scripts\
         Creates a Cisco UCS As Built Report in default format (Word) with a customised style.
         The report will be saved to c:\scripts.
     .EXAMPLE
-        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Report Nutanix.AOS -SendEmail -OutputPath c:\scripts\
-
-        Creates a Nutanix AOS As Built Report in default format (Word). Report will be attached and sent via email.
+        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Report Nutanix.PrismElement -SendEmail -OutputFolderPath c:\scripts\
+        Creates a Nutanix Prism Element As Built Report in default format (Word). Report will be attached and sent via email.
         The report will be saved to c:\scripts.
     .EXAMPLE
-        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Format HTML -Report VMware.vSphere -AsBuiltConfigPath C:\scripts\asbuiltreport.json -OutputPath c:\scripts\
+        PS C:\>New-AsBuiltReport -Target 192.168.1.100 -Username admin -Password admin -Format HTML -Report VMware.vSphere -AsBuiltConfigFilePath C:\scripts\asbuiltreport.json -OutputFolderPath c:\scripts\
         
         Creates a VMware vSphere As Built Report in HTML format, using the configuration in the asbuiltreport.json file located in the C:\scripts\ folder.
         The report will be saved to c:\scripts.
     .NOTES
-        Version:        1.0.5
+        Version:        1.1.0
         Author(s):      Tim Carman / Matt Allford
         Twitter:        @tpcarman / @mattallford
         Github:         AsBuiltReport
@@ -151,7 +149,6 @@ function New-AsBuiltReport {
         [Array] $Format = 'Word',
 
         [Parameter(
-            Position = 5,
             Mandatory = $false,
             HelpMessage = 'Determines the document page orientation'
         )]
@@ -163,27 +160,40 @@ function New-AsBuiltReport {
             Mandatory = $true,
             HelpMessage = 'Please provide the path to the document output file'
         )]
-        [ValidateNotNullOrEmpty()] 
-        [String] $OutputPath,
+        [ValidateNotNullOrEmpty()]
+        [Alias('OutputPath')] 
+        [String] $OutputFolderPath,
 
         [Parameter(
             Mandatory = $false,
             HelpMessage = 'Please provide the path to the custom style script'
         )]
         [ValidateNotNullOrEmpty()] 
-        [String] $StylePath,
+        [Alias('StylePath')] 
+        [String] $StyleFilePath,
 
         [Parameter(
             Mandatory = $false,
             HelpMessage = 'Provide the file path to an existing report JSON Configuration file'
         )]
-        [string] $ReportConfigPath,
+        [ValidateNotNullOrEmpty()]
+        [Alias('ReportConfigPath')] 
+        [string] $ReportConfigFilePath,
 
         [Parameter(
             Mandatory = $false,
             HelpMessage = 'Provide the file path to an existing As Built JSON Configuration file'
         )]
-        [string] $AsBuiltConfigPath,
+        [ValidateNotNullOrEmpty()]
+        [Alias('AsBuiltConfigPath')] 
+        [string] $AsBuiltConfigFilePath,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'Specify the As Built Report filename'
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string] $Filename,
 
         [Parameter(
             Mandatory = $false,
@@ -213,65 +223,78 @@ function New-AsBuiltReport {
             $Credential = New-Object System.Management.Automation.PSCredential ($Username, $SecurePassword)
         }
 
-        if (!(Test-Path $OutputPath)) {
-            Write-Error "OutputPath $OutputPath is not a valid directory path"
+        if (!(Test-Path $OutputFolderPath)) {
+            Write-Error "OutputFolderPath '$OutputFolderPath' is not a valid folder path."
             break
         }
         #region Variable config
 
         # Import the AsBuiltReport JSON configuration file
         # If no path was specified, or the specified file doesn't exist, call New-AsBuiltConfig to walk the user through the menu prompt to create a config JSON
-        if ($AsBuiltConfigPath) {
-            if (Test-Path -Path $AsBuiltConfigPath) {
-                $Global:AsBuiltConfig = Get-Content -Path $AsBuiltConfigPath | ConvertFrom-Json
+        if ($AsBuiltConfigFilePath) {
+            if (Test-Path -Path $AsBuiltConfigFilePath) {
+                $Global:AsBuiltConfig = Get-Content -Path $AsBuiltConfigFilePath | ConvertFrom-Json
+                # Verbose Output for As Built Report configuration
+                Write-Verbose -Message "Loading As Built Report configuration from '$AsBuiltConfigFilePath'."
+            } else {
+                Write-Error "Could not find As Built Report configuration in path '$AsBuiltConfigFilePath'."
+                break 
             }
         } else {
+            Write-Verbose -Message "Generating new As Built Report configuration"
             $Global:AsBuiltConfig = New-AsBuiltConfig
         }
 
-        # Set ReportConfigPath as Global scope for use in New-AsBuiltConfig
-        if ($ReportConfigPath) {
-            $Global:ReportConfigPath = $ReportConfigPath
+        # Set ReportConfigFilePath as Global scope for use in New-AsBuiltConfig
+        if ($ReportConfigFilePath) {
+            $Global:ReportConfigFilePath = $ReportConfigFilePath
         }
 
-        # If Stylepath was specified, ensure the file provided in the path exists, otherwise exit with error
-        if ($StylePath) {
-            if (!(Test-Path -Path $StylePath)) {
-                Write-Error "Could not find a style script at $StylePath"
+        # If StyleFilePath was specified, ensure the file provided in the path exists, otherwise exit with error
+        if ($StyleFilePath) {
+            if (!(Test-Path -Path $StyleFilePath)) {
+                Write-Error "Could not find report style script in path '$StyleFilePath'."
                 break
             }
         }
 
-        $ReportModule = "AsBuiltReport.$Report"
+        # Report Module Information
+        $Global:Report = $Report
+        $ReportModuleName = "AsBuiltReport.$Report"
+        $ReportModulePath = (Get-Module -Name $ReportModuleName -ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1).ModuleBase
 
-        if ($ReportConfigPath) {
-            # If ReportConfigPath was specified, ensure the file provided in the path exists, otherwise exit with error
-            if (!(Test-Path -Path $ReportConfigPath)) {
-                Write-Error "Could not find a style script at $ReportConfigPath"
+        if ($ReportConfigFilePath) {
+            # If ReportConfigFilePath was specified, ensure the file provided in the path exists, otherwise exit with error
+            if (!(Test-Path -Path $ReportConfigFilePath)) {
+                Write-Error "Could not find $ReportModuleName report configuration file in path '$ReportConfigFilePath'."
                 break
             } else {
                 #Import the Report Configuration in to a variable
-                $Global:ReportConfig = Get-Content -Path $ReportConfigPath | ConvertFrom-Json
+                Write-Verbose -Message "Loading $ReportModuleName report configuration file from path '$ReportConfigFilePath'."
+                $Global:ReportConfig = Get-Content -Path $ReportConfigFilePath | ConvertFrom-Json
             }
         } else {
             # If a report config hasn't been provided, check for the existance of the default JSON in the paths the user specified in base config
-            $ReportConfigPath = Join-Path -Path $AsBuiltConfig.UserFolder.Path -ChildPath "$ReportModule.json"
-            
-            if (Test-Path -Path $ReportConfigPath) {
-                $Global:ReportConfig = Get-Content -Path $ReportConfigPath | ConvertFrom-Json
-            } else {
-                # Create the report JSON and save it in the UserFolder specified in the Base Config
-                New-AsBuiltReportConfig -Report $Report -Path $AsBuiltConfig.UserFolder.Path
-                $Global:ReportConfig = Get-Content -Path $ReportConfigPath | ConvertFrom-Json
-            }#End if test-path
-        }#End if ReportConfigPath
+            $ReportConfigFilePath =  "$ReportModulePath\$ReportModuleName.json"
 
-        # If Timestamp parameter is specified, add the timestamp to the report filename 
-        if ($Timestamp) {
-            $FileName = $ReportConfig.Report.Name + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
-        } else {
+            if (Test-Path -Path $ReportConfigFilePath) {
+                Write-Verbose -Message "Loading report configuration file from path '$ReportConfigFilePath'."
+                $Global:ReportConfig = Get-Content -Path $ReportConfigFilePath | ConvertFrom-Json
+            } else {
+                Write-Error "Report configuration file not found in module path '$ReportModulePath'."
+                break
+            }#End if test-path
+        }#End if ReportConfigFilePath
+
+        # If Filename parameter is not specified, set filename to the report name
+        if (!$Filename) {
             $FileName = $ReportConfig.Report.Name
         }
+        # If Timestamp parameter is specified, add the timestamp to the report filename 
+        if ($Timestamp) {
+            $FileName = $Filename + " - " + (Get-Date -Format 'yyyy-MM-dd_HH.mm.ss')
+        }
+        Write-Verbose -Message "Setting report filename to '$FileName'."
 
         # If the EnableHealthCheck parameter has been specified, set the global healthcheck variable so report scripts can reference the health checks
         if ($EnableHealthCheck) {
@@ -300,25 +323,36 @@ function New-AsBuiltReport {
         if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) {
             $AsBuiltReport = Document $FileName -Verbose {
                 # Set Document Style
-                if ($StylePath) {
-                    .$StylePath
+                if ($StyleFilePath) {
+                    Write-PScriboMessage "Executing report style script from path '$StyleFilePath'."
+                    . $StyleFilePath
+                } else {
+                    Write-PScriboMessage "Executing report style script from path '$ReportModulePath\$ReportModuleName.Style.ps1'."
+                    . "$ReportModulePath\$ReportModuleName.Style.ps1"
                 }
-    
-                & "Invoke-$($ReportModule)" -Target $Target -Credential $Credential -StylePath $StylePath -Verbose
+                # StylePath parameter is legacy, to allow older reports to be generated without issues. It will be removed at a later date.
+                & "Invoke-$($ReportModuleName)" -Target $Target -Credential $Credential -Verbose -StylePath $true
             }
         } else {
             $AsBuiltReport = Document $FileName {
+
+                Write-Host "Please wait while the $($Report.Replace("."," ")) As Built Report is being generated." -ForegroundColor Green
+
                 # Set Document Style
-                if ($StylePath) {
-                    .$StylePath
+                if ($StyleFilePath) {
+                    Write-PScriboMessage "Executing report style script from path '$StyleFilePath'."
+                    . $StyleFilePath
+                } else {
+                    Write-PScriboMessage "Executing report style script from path '$ReportModulePath\$ReportModuleName.Style.ps1'."
+                    . "$ReportModulePath\$ReportModuleName.Style.ps1"
                 }
-    
-                & "Invoke-$($ReportModule)" -Target $Target -Credential $Credential -StylePath $StylePath
+                # StylePath parameter is legacy, to allow older reports to be generated without issues. It will be removed at a later date.
+                & "Invoke-$($ReportModuleName)" -Target $Target -Credential $Credential -StylePath $true
             }
         }
         Try {
-            $Document = $AsBuiltReport | Export-Document -Path $OutputPath -Format $Format -Options @{ TextWidth = 240 } -PassThru
-            Write-Output "$FileName has been saved to $OutputPath"
+            $Document = $AsBuiltReport | Export-Document -Path $OutputFolderPath -Format $Format -Options @{ TextWidth = 240 } -PassThru
+            Write-Output "$($Report.Replace("."," ")) As Built Report '$FileName' has been saved to '$OutputFolderPath'."
         } catch {
             $Err = $_
             Write-Error $Err
@@ -351,9 +385,10 @@ function New-AsBuiltReport {
         #region Globals cleanup
         Remove-Variable -Name AsBuiltConfig -Scope Global
         Remove-Variable -Name ReportConfig -Scope Global
+        Remove-Variable -Name Report -Scope Global
         Remove-Variable -Name Orientation -Scope Global
-        if ($ReportConfigPath) {
-            Remove-Variable -Name ReportConfigPath
+        if ($ReportConfigFilePath) {
+            Remove-Variable -Name ReportConfigFilePath
         }
         if ($Healthcheck) {
             Remove-Variable -Name Healthcheck -Scope Global

--- a/Src/Public/New-AsBuiltReportConfig.ps1
+++ b/Src/Public/New-AsBuiltReportConfig.ps1
@@ -6,19 +6,19 @@ function New-AsBuiltReportConfig {
         Creates JSON configuration files for individual As Built Reports.
     .PARAMETER Report
         Specifies the type of report configuration to create.
-    .PARAMETER Path
-        Specifies the path to create the report JSON configuration file.
-    .PARAMETER Name
-        Specifies the name of the report JSON configuration file.
+    .PARAMETER FolderPath
+        Specifies the folder path to create the report JSON configuration file.
+    .PARAMETER Filename
+        Specifies the filename of the report JSON configuration file.
         If Name is not specified, a JSON configuration file will be created with a default name AsBuiltReport.<Vendor>.<Product>.json
-    .PARAMETER Overwrite
+    .PARAMETER Force
         Specifies to overwrite any existing report JSON configuration file
     .EXAMPLE
         Creates a report configuration file for VMware vSphere, named 'vSphere_Report_Config' in 'C:\Reports' folder. 
-        New-AsBuiltReportConfig -Report VMware.vSphere -Path 'C:\Reports' -Name 'vSphere_Report_Config'
+        New-AsBuiltReportConfig -Report VMware.vSphere -FolderPath 'C:\Reports' -Filename 'vSphere_Report_Config'
     .EXAMPLE
         Creates a report configuration file for Nutanix Prism Central, named 'AsBuiltReport.Nutanix.PrismCentral' in 'C:\Reports' folder, overwriting any existing file. 
-        New-AsBuiltReportConfig -Report Nutanix.PrismCentral -Path 'C:\Reports' -Overwrite
+        New-AsBuiltReportConfig -Report Nutanix.PrismCentral -FolderPath 'C:\Reports' -Overwrite
     #>
     [CmdletBinding()]
     param (
@@ -43,54 +43,66 @@ function New-AsBuiltReportConfig {
 
         [Parameter(
             Mandatory = $true,
-            HelpMessage = 'Please provide the path to save the JSON configuration file'
+            HelpMessage = 'Please provide the folder path to save the JSON configuration file'
         )]
         [ValidateNotNullOrEmpty()]
-        [String] $Path,
+        [Alias('Path')] 
+        [String] $FolderPath,
 
         [Parameter(
             Mandatory = $false,
-            HelpMessage = 'Please provide the name of the JSON configuration file'
+            HelpMessage = 'Please provide the filename of the JSON configuration file'
         )]
         [ValidateNotNullOrEmpty()]
-        [String] $Name,
+        [Alias('Name')]
+        [String] $Filename,
 
         [Parameter(
             Mandatory = $false,
             HelpMessage = 'Used to overwrite the destination file if it exists'
         )]
         [ValidateNotNullOrEmpty()]
-        [Switch] $Overwrite
+        [Alias('Overwrite')]
+        [Switch] $Force
     )
 
     # Test to ensure the path the user has specified does exist
-    if (!(Test-Path -Path $Path)) {
-        Write-Error "The Path $Path does not exist. Please create the folder and re-run New-AsBuiltReportConfig"
+    if (!(Test-Path -Path $FolderPath)) {
+        Write-Error "The Path '$FolderPath' does not exist. Please create the folder and run New-AsBuiltReportConfig again."
         break
     }
     # Find the root folder where the module is located for the report that has been specified
     try {
         $Module = Get-Module -Name "AsBuiltReport.$Report" -ListAvailable | Where-Object { $_.name -ne 'AsBuiltReport.Core' } | Sort-Object -Property Version -Descending | Select-Object -Unique
-        if ($Name) {
-            if (!(Test-Path -Path "$($Path)\$($Name).json")) {
-                Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination "$($Path)\$($Name).json"
-                Write-Output "$Name JSON configuration file created in $Path"
-            } elseif ($Overwrite) {
-                Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination "$($Path)\$($Name).json" -Force
-                Write-Output "$Name JSON configuration file created in $Path"
+        if (Test-Path -Path "$($Module.ModuleBase)\$($Module.Name).json") {
+            Write-Verbose -Message "Processing report configuration file from module $($Module), version $($Module.Version)."
+            if ($Filename) {
+                if (!(Test-Path -Path "$($FolderPath)\$($Filename).json")) {
+                    Write-Verbose -Message "Copying report configuration file '$($Module.ModuleBase)\$($Module.Name).json' to '$($FolderPath)\$($Filename).json'."
+                    Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination "$($FolderPath)\$($Filename).json"
+                    Write-Output "Report configuration file '$($Filename).json' created in '$FolderPath'."
+                } elseif ($Force) {
+                    Write-Verbose -Message "Copying report configuration file '$($Module.ModuleBase)\$($Module.Name).json' to '$($FolderPath)\$($Filename).json'. Overwriting existing file."
+                    Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination "$($FolderPath)\$($Filename).json" -Force
+                    Write-Output "Report configuration file '$($Filename).json' created in '$FolderPath'."
+                } else {
+                    Write-Error "Report configuration file '$($Filename).json' already exists in '$FolderPath'. Use 'Force' parameter to overwrite existing file."
+                }
             } else {
-                Write-Error "$Name filename already exists in $Path"
+                if (!(Test-Path -Path "$($FolderPath)\$($Module.Name).json")) {
+                    Write-Verbose -Message "Copying report configuration file '$($Module.ModuleBase)\$($Module.Name).json' to destination folder '$FolderPath'."
+                    Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination $FolderPath
+                    Write-Output "Report configuration file '$($Module.Name).json' created in '$FolderPath'."
+                } elseif ($Force) {
+                    Write-Verbose -Message "Copying report configuration file '$($Module.ModuleBase)\$($Module.Name).json' to destination folder '$FolderPath'. Overwriting existing file."
+                    Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination $FolderPath -Force
+                    Write-Output "Report configuration file '$($Module.Name).json' created in '$FolderPath'."
+                } else {
+                    Write-Error "Report configuration file '$($Module.Name).json' already exists in '$FolderPath'. Use 'Force' parameter to overwrite existing file."
+                }
             }
         } else {
-            if (!(Test-Path -Path "$($Path)\$($Module.Name).json")) {
-                Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination $Path
-                Write-Output "$($Module.Name) JSON configuration file created in $Path"
-            } elseif ($Overwrite) {
-                Copy-Item -Path "$($Module.ModuleBase)\$($Module.Name).json" -Destination $Path -Force
-                Write-Output "$($Module.Name) JSON configuration file created in $Path"
-            } else {
-                Write-Error "$($Module.Name).json report configuration already exists in $Path"
-            }
+            Write-Error "Report configuration file not found in module path '$($Module.ModuleBase)'."
         }
     } catch {
         Write-Error $_


### PR DESCRIPTION
## Description
- Updated `New-AsBuiltReport` parameter names to provide clarity of input requirements. Aliases used to prevent breaking changes.
    - `OutputPath` now an alias for `OutputFolderPath`
    - `StylePath` now an alias for `StyleFilePath`
    - `ReportConfigPath` now an alias for `ReportConfigFilePath`
    - `AsBuiltConfigPath` now an alias for `AsBuiltConfigFilePath`
- Updated `New-AsBuiltReportConfig` parameter names to provide clarity of input requirements. Aliases used to prevent breaking changes.
    - `Path` now an alias for `FolderPath`
    - `Name` now an alias for `Filename`
    - `Overwrite` now an alias for `Force`
- Updated `RequiredModules` for PScribo 0.9.1
- Custom style scripts are now executed from `New-AsBuiltReport` to allow use of new PScribo features

### Added
- Added `Filename` parameter to `New-AsBuiltReport`
- Added error check for incorrect `AsBuiltConfigFilePath`
- Improvements to verbose logging

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
