### PR TITLE
Add MFA Window Notification Message

### DIFF
--- a/Src/Public/New-AsBuiltReport.ps1
+++ b/Src/Public/New-AsBuiltReport.ps1
@@ -374,7 +374,8 @@ function New-AsBuiltReport {
             $AsBuiltReport = Document $FileName {
 
                 Write-Host "Please wait while the $($Report.Replace("."," ")) As Built Report is being generated." -ForegroundColor Green
-
+                if ($MFA) {
+                    Write-Host "MFA is enabled, please check for MFA authentication windows to complete your report" -ForegroundColor Yellow}
                 # Set Document Style
                 if ($StyleFilePath) {
                     Write-PScriboMessage "Executing report style script from path '$StyleFilePath'."


### PR DESCRIPTION
Added a notification message to New-AsBuiltReport to advise users of a potential hidden window when using MFA

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a new Write-Host prompt when the $MFA variable is set, displays a message to encourage the user to look for an MFA window that may have appeared underneath the current window.

## Related Issue
#45 

## Motivation and Context
Provides user feedback for PowerShell modules that don't launch their MFA window as Modal 

## How Has This Been Tested?
Tested in VsCode, PsISE and Windows Terminal against my own module.

## Screenshots (if appropriate):
![image](https://github.com/AsBuiltReport/AsBuiltReport.Core/assets/8736291/d67e5785-d74d-4b68-a4ce-178792551b77)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) page.
