### PR TITLE
Fix Write-Host error message

### DIFF
--- a/Src/Private/Initialize-LocalizedData.ps1
+++ b/Src/Private/Initialize-LocalizedData.ps1
@@ -205,7 +205,7 @@ function Initialize-LocalizedData {
         if ($TargetCulture -ne $Culture.Name) {
             Write-Warning -Message ("Setting language to '{0}' (fallback from '{1}'){2}." -f $TargetCulture, $Culture.Name, $PathInfo)
         } else {
-            Write-Host "Setting language to '{0}'{1}" -f $TargetCulture, $PathInfo -ForegroundColor Green
+            Write-Host ("Setting language to '{0}'{1}" -f $TargetCulture, $PathInfo) -ForegroundColor Green
         }
 
         # Mark this combination as already shown


### PR DESCRIPTION
## Description

- Fix Error:

```powershell
Write-Host : Cannot bind parameter 'ForegroundColor'. Cannot convert value "en-US, from core module" to type "System.ConsoleColor". Error: "Unable to match the identifier name en-US, from core 
module to a valid enumerator name. Specify one of the following enumerator names and try again:
Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White"
At C:\Users\jocolon\Documents\WindowsPowerShell\Modules\AsBuiltReport.Core\Src\Private\Initialize-LocalizedData.ps1:208 char:58
+ ... t "Setting language to '{0}'{1}" -f $TargetCulture, $PathInfo -Foregr ...
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Write-Host], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.WriteHostCommand
```

## Related Issue

- Fix #59 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://www.asbuiltreport.com/about/contributing/) page.
