### PR TITLE
v1.6.4 - Fix verbose output always enabled on Windows PowerShell 5.1

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -26,22 +26,6 @@ jobs:
         shell: pwsh
         run: |
           Publish-Module -Path .\AsBuiltReport.Core\ -NuGetApiKey ${{ secrets.PSGALLERY_API_KEY }} -Verbose
-  tweet:
-    needs: publish-to-gallery
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Eomm/why-don-t-you-tweet@v2
-        # We don't want to tweet if the repository is not a public one
-        if: ${{ !github.event.repository.private }}
-        with:
-          # GitHub event payload
-          # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
-          tweet-message: "[New Release] ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}! Check out what's new! ${{ github.event.release.html_url }} #AsBuiltReport #PowerShell"
-        env:
-          TWITTER_CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-          TWITTER_CONSUMER_API_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
-          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
   bsky-post:
     needs: publish-to-gallery
     runs-on: ubuntu-latest

--- a/AsBuiltReport.Core/AsBuiltReport.Core.psd1
+++ b/AsBuiltReport.Core/AsBuiltReport.Core.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion = '1.6.3'
+    ModuleVersion = '1.6.4'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop', 'Core')

--- a/AsBuiltReport.Core/Src/Public/New-AsBuiltReport.ps1
+++ b/AsBuiltReport.Core/Src/Public/New-AsBuiltReport.ps1
@@ -520,7 +520,7 @@ function New-AsBuiltReport {
 
         #region Generate PScribo document
         # if Verbose has been passed
-        if ($PSBoundParameters.ContainsKey('Verbose')) {
+        if ($PSCmdlet.MyInvocation.BoundParameters['Verbose'].IsPresent) {
             $AsBuiltReport = Document $FileName -Verbose {
                 Write-PScriboMessage -Plugin 'Document' -Message ($translate.ReportGenerating -f $($Report.Replace('.', ' ')))
                 # Set Document Style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix verbose output always enabled on Windows PowerShell 5.1 when `-Verbose` is not explicitly passed (Fix [#77](https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/77))
 
+### Removed
+- Remove X (Twitter) post action from release workflow due to API costs
+
 ## [1.6.3] - 2026-05-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-05-15
+
+### Fixed
+- Fix verbose output always enabled on Windows PowerShell 5.1 when `-Verbose` is not explicitly passed (Fix [#77](https://github.com/AsBuiltReport/AsBuiltReport.Core/issues/77))
+
 ## [1.6.3] - 2026-05-12
 
 ### Changed


### PR DESCRIPTION
## Summary

- Reverts `$PSBoundParameters.ContainsKey('Verbose')` back to `$PSCmdlet.MyInvocation.BoundParameters['Verbose'].IsPresent` in `New-AsBuiltReport` to fix verbose output being unconditionally enabled on Windows PowerShell 5.1
- Bumps module version to `1.6.4`
- Updates `CHANGELOG.md` with `[1.6.4]` entry

Closes #77

## Root Cause

The v1.6.3 change (commit `5e635d4`, applied from a Copilot suggestion) swapped the verbose detection check:

```powershell
# Before (v1.6.2) — correct
if ($PSCmdlet.MyInvocation.BoundParameters['Verbose'].IsPresent) {

# After (v1.6.3) — broken on Windows PowerShell 5.1
if ($PSBoundParameters.ContainsKey('Verbose')) {
```

In Windows PowerShell 5.1, the `Verbose` common parameter is automatically added to `$PSBoundParameters` with a value of `[SwitchParameter]$false` even when `-Verbose` is not explicitly passed. This caused `ContainsKey('Verbose')` to always return `$true`, making `New-AsBuiltReport` unconditionally pass `-Verbose` to the PScribo `Document { }` block and every `Invoke-<ReportModule>` call. PowerShell 7+ does not exhibit this behaviour, which is why the regression was Windows-only.

## Test plan

- [ ] Run `New-AsBuiltReport` on Windows PowerShell 5.1 **without** `-Verbose` and confirm no verbose output is produced
- [ ] Run `New-AsBuiltReport` on Windows PowerShell 5.1 **with** `-Verbose` and confirm verbose output is produced
- [ ] Run `New-AsBuiltReport` on PowerShell 7+ with and without `-Verbose` and confirm behaviour is unchanged
- [ ] Confirm CI passes (Pester + PSScriptAnalyzer)

https://claude.ai/code/session_019hdGnHpEF3UevtELrNtidw

---
_Generated by [Claude Code](https://claude.ai/code/session_019hdGnHpEF3UevtELrNtidw)_